### PR TITLE
feat: multiple routers

### DIFF
--- a/bin/main.dart
+++ b/bin/main.dart
@@ -1,5 +1,4 @@
 import 'package:h4/create.dart';
-import 'package:h4/utils/req_utils.dart';
 import 'package:h4/utils/get_query.dart';
 
 void main() async {
@@ -14,14 +13,9 @@ void main() async {
 
   var router = createRouter();
 
-  app.use(router);
+  app.use(router, basePath: '/');
 
-  router.get<Future<String>>("/", (event) async {
-    // Still 'Ogunlepon'
-    print(event.context["user"]);
-    print(getQueryParams(event));
-    var formdata = await readFormData(event);
-    print(formdata.getAll('file'));
-    return 'Hello world';
+  router.get("/", (event) async {
+    return 'Hello';
   });
 }

--- a/bin/main.dart
+++ b/bin/main.dart
@@ -1,5 +1,4 @@
 import 'package:h4/create.dart';
-import 'package:h4/utils/get_query.dart';
 
 void main() async {
   var app = createApp(
@@ -12,10 +11,16 @@ void main() async {
   );
 
   var router = createRouter();
+  var apiRouter = createRouter();
 
   app.use(router, basePath: '/');
+  app.use(apiRouter, basePath: '/api');
 
-  router.get("/", (event) async {
-    return 'Hello';
+  router.get("/", (event) {
+    return 'Hello from /';
+  });
+
+  apiRouter.get("/", (event) {
+    return 'Hi from /api';
   });
 }

--- a/lib/src/extract_path_pieces.dart
+++ b/lib/src/extract_path_pieces.dart
@@ -1,6 +1,8 @@
+import 'package:h4/src/logger.dart';
+
 List<String> extractPieces(String path) {
   if (!isValidHttpPathPattern(path)) {
-    throw FormatException('Invalid http path, Got - $path');
+    logger.severe('Invalid http path, Got - $path');
   }
   List<String> result = path == '/' ? [] : path.split('/')
     ..removeWhere((piece) => piece.isEmpty);
@@ -17,6 +19,7 @@ bool isValidHttpPathPattern(String pattern) {
     r'|/[\p{L}\p{N}_-]+/:[^/]+/\*\*'
     r'|/[\p{L}\p{N}_-]+/\*\*'
     r'|/[\p{L}\p{N}_-]+/\*'
+    r'|'
     r'|\*'
     r')$',
     unicode: true,

--- a/lib/src/h4.dart
+++ b/lib/src/h4.dart
@@ -185,6 +185,11 @@ class H4 {
       String routeKey = '';
 
       for (var key in routeStack.keys) {
+        if (!key.startsWith('/')) {
+          logger.warning(
+              'Invalid base path! - found $key - change the base path to /$key');
+        }
+
         if (key != '/') {
           if (request.uri.path.startsWith(key)) {
             hRouter = routeStack[key];
@@ -192,11 +197,16 @@ class H4 {
           }
         } else {
           hRouter = routeStack['/'];
-          routeKey = key;
+          routeKey = '/';
         }
       }
 
-      var routePath = request.uri.path.replaceFirstMapped(routeKey, (m) => '/');
+      var routePath = request.uri.path;
+
+      if (routeKey != '/') {
+        routePath = request.uri.path.replaceFirstMapped(
+            routeKey, (m) => m.toString() == routeKey ? '/' : '');
+      }
 
       // Find handler for that request
       var match = hRouter?.lookup(routePath);

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -22,9 +22,15 @@ initLogger() {
 
       case 'SEVERE':
         {
-          Console.setFramed(true);
-          Console.write(record.level.name);
-          Console.write(record.message);
+          Console.setBackgroundColor(1, bright: true);
+          Console.setTextColor(0, bright: true);
+          // ignore: unnecessary_string_escapes
+          Console.write('\n ${record.level.name} ');
+          Console.resetBackgroundColor();
+          Console.resetTextColor();
+          Console.setBold(false);
+          Console.write(' ▲▼ ${record.message}\n');
+          Console.resetAll();
         }
     }
   });

--- a/test/h4_test.dart
+++ b/test/h4_test.dart
@@ -1,8 +1,11 @@
+import 'dart:convert';
+
 import 'package:dio/dio.dart';
 
 import 'package:h4/create.dart';
 import 'package:h4/src/h4.dart';
 import 'package:h4/src/router.dart';
+import 'package:h4/utils/get_query.dart';
 import 'package:h4/utils/read_request_body.dart';
 import 'package:test/test.dart';
 
@@ -132,5 +135,15 @@ void main() {
           headers: {'content-type': 'application/json'},
         ));
     expect(req.data, '{"hi":12}');
+  });
+
+  test('Correctly parses query parameters', () async {
+    router.get('/body', (event) async {
+      return await getQueryParams(event);
+    });
+
+    final response = await dio.get('/body?query=iyimide&answer=laboss');
+
+    expect(jsonDecode(response.data), {"query": "iyimide", "answer": "laboss"});
   });
 }


### PR DESCRIPTION
### You can now use multiple routers in H4
```dart
void main() async {
  var app = createApp(
    port: 5173,
    onRequest: (event) {},
    afterResponse: (event) => {},
  );

  var router = createRouter();
  var apiRouter = createRouter();

  app.use(router, basePath: '/');
  app.use(apiRouter, basePath: '/api');

  router.get("/", (event) {
    return 'Hello from /';
  });

  apiRouter.get("/", (event) {
    return 'Hi from /api';
  });
}
```

Non breaking change to `app.use(H4Router)` which can now be extended to be 

`app.use(H4Router, basePath: String)`